### PR TITLE
Update metadata with tags & unify formatting

### DIFF
--- a/REMARKs/BayerLuetticke.md
+++ b/REMARKs/BayerLuetticke.md
@@ -1,0 +1,5 @@
+---
+tags:
+  - REMARK
+  - Reproduction
+---

--- a/REMARKs/BlanchardPA2019.md
+++ b/REMARKs/BlanchardPA2019.md
@@ -2,18 +2,20 @@
 tags:
   - REMARK
   - Replication
-location_url: https://github.com/econ-ark/BlanchardPA2019
-name: BlanchardPA2019
-remark_title: 'Public Debt and Low Interest Rates'
-summary: ''
-abstract: ''
-notebook: Code/Python/BlanchardPA2019.ipynb
-authors:
-  - Julien Acalin
-DOI: ''
+abstract: # abstract: optional
+authors: # required
+  -
+    family-names: Acalin
+    given-names: "Julien"
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+# REMARK fields
+github_repo_url: https://github.com/econ-ark/BlanchardPA2019 # required 
+remark-name: BlanchardPA2019 # required 
+title-original-paper: Public Debt and Low Interest Rates # optional 
+notebooks: # path to any notebooks within the repo - optional
+  - 
+    BlanchardPA2019.ipynb
 ---
-
-
 
 # Public Debt and Low Interest Rates
 

--- a/REMARKs/BlanchardPA2019.md
+++ b/REMARKs/BlanchardPA2019.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Replication
 location_url: https://github.com/econ-ark/BlanchardPA2019
 name: BlanchardPA2019
 remark_title: 'Public Debt and Low Interest Rates'

--- a/REMARKs/BufferStockTheory.md
+++ b/REMARKs/BufferStockTheory.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Reproduction
 abstract: "This paper builds theoretical foundations for rigorous and intuitive understanding of 'buffer stock' saving models, pairing each theoretical result with a quantitative exploration.  After describing conditions under which the consumption function converges, the paper shows that 'target' saving behavior, which defines buffer stock saving, arises only under conditions strictly stronger than those that guarantee convergence of the consumption and value functions.  It also shows that average consumption growth equals average income growth in a small open economy populated by buffer stock savers.  Together, the (provided) numerical tools and (proven) analytical results constitute a comprehensive toolkit for understanding buffer stock models." # abstract: optional
 authors: # required
   -

--- a/REMARKs/CGMPortfolio.md
+++ b/REMARKs/CGMPortfolio.md
@@ -1,4 +1,6 @@
 ---
+tags:
+  - REMARK
 abstract: "This REMARK is an attempt to reproduce the main results of Cocco, Gomes, & Maenhout (2005), 'Consumption and Portfolio Choice Over the Life Cycle' (https://academic.oup.com/rfs/article-abstract/18/2/491/1599892)" # abstract: optional
 authors: # required
   -

--- a/REMARKs/Carroll_1997_QJE.md
+++ b/REMARKs/Carroll_1997_QJE.md
@@ -1,21 +1,30 @@
 ---
 tags:
   - REMARK
-location_url: https://github.com/econ-ark/Carroll_1997_QJE
-name: Carroll_1997_QJE
-paper_title: Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis
-remark_title: Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis
-summary: ''
-abstract: ''
-notebook: Code/Python/Carroll_1997_QJE.ipynb
-paper_authors:
-  - Christopher D. Carroll
-remark_authors:
-  - Yusuf Suha Kulu
-  - Jeongwon (John) Son
-DOI: 
+abstract: # abstract: optional
+authors: # required
+  -
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+  - 
+    family-names: Yusuf
+    given-names: "Suha Kulu"
+  - 
+    family-names: Son
+    given-names: "Jeongwon (John)"
+# REMARK fields
+github_repo_url: https://github.com/econ-ark/Carroll_1997_QJE # required 
+commit: # Git commit number that the REMARK will always use; required for "frozen" remarks, optional for "draft" remarks
+remark-name: Carroll_1997_QJE # required 
+title-original-paper: Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis # optional 
+notebooks: # path to any notebooks within the repo - optional
+  - 
+    Carroll_1997_QJE.ipynb
+dashboards: # path to any dahsboards within the repo - optional
+identifiers-paper: # required for Replications; optional for Reproductions
+date-published-original-paper: # required for Replications; optional for Reproductions
 ---
-
 
 # Carroll_1997_QJE
 

--- a/REMARKs/Carroll_1997_QJE.md
+++ b/REMARKs/Carroll_1997_QJE.md
@@ -1,4 +1,6 @@
 ---
+tags:
+  - REMARK
 location_url: https://github.com/econ-ark/Carroll_1997_QJE
 name: Carroll_1997_QJE
 paper_title: Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis

--- a/REMARKs/EndogenousRetirement.md
+++ b/REMARKs/EndogenousRetirement.md
@@ -1,4 +1,6 @@
 ---
+tags:
+  - REMARK
 location_url: https://github.com/econ-ark/EndogenousRetirement
 name: EndogenousRetirement
 summary: ''

--- a/REMARKs/GanongNoelUI.md
+++ b/REMARKs/GanongNoelUI.md
@@ -1,3 +1,9 @@
+---
+tags:
+  - REMARK
+  - Replication
+---
+  
   Analysis of Models for "Consumer Spending During Unemployment: Positive and Normative Implications"
 
 By Peter Ganong and Pascal Noel 

--- a/REMARKs/KrusellSmith.md
+++ b/REMARKs/KrusellSmith.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Replication
 location_url: https://github.com/econ-ark/KrusellSmith
 name: KrusellSmith
 summary: 'Income and wealth heterogeneity in the macroeconomy'

--- a/REMARKs/LiqConstr.md
+++ b/REMARKs/LiqConstr.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Reproduction
 abstract: "We provide the analytical explanation of strong interactions between precautionary sav- ing and liquidity constraints that are regularly observed in numerical solutions to consump- tion/saving models. The effects of constraints and of uncertainty spring from the same cause: concavification of the consumption function, which can be induced either by constraints or by uncertainty. Concavification propagates back to consumption functions in prior periods. But, surprisingly, once a linear consumption function has been concavified by the presence of either risks or constraints, the introduction of additional concavifiers in a given period can reduce the precautionary motive in earlier periods at some levels of wealth." # abstract: optional
 authors: # required
   -

--- a/REMARKs/Pandemic.md
+++ b/REMARKs/Pandemic.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Notebook
 abstract: "To predict the eﬀects of the 2020 U.S. CARES Act on consumption, we extend a model that matches responses of households to past consumption stimulus packages. The extension allows us to account for two novel features of the coronavirus crisis. First, during the lockdown, many types of spending are undesirable or impossible. Second, some of the jobs that disappear during the lockdown will not reappear when it is lifted. We estimate that, if the lockdown is short-lived, the combination of expanded unemployment insurance beneﬁts and stimulus payments should be suﬃcient to allow a swift recovery in consumer spending to its pre-crisis levels. If the lockdown lasts longer, an extension of enhanced unemployment beneﬁts will likely be necessary if consumption spending is to recover." # abstract: optional
 authors: # required
   -

--- a/REMARKs/PortfolioChoiceBlogPost.md
+++ b/REMARKs/PortfolioChoiceBlogPost.md
@@ -1,4 +1,9 @@
 ---
+tags:
+  - REMARK
+  - Replication
+  - Notebook
+  - Blog
 location_url: https://github.com/econ-ark/PortfolioChoiceBlogPost
 name: PortfolioChoiceBlogPost
 summary: 'Optimal Financial Investment over the Life Cycle'

--- a/REMARKs/SolvingMicroDSOPs.md
+++ b/REMARKs/SolvingMicroDSOPs.md
@@ -1,3 +1,10 @@
+---
+tags:
+  - REMARK
+  - Replication
+  - Teaching
+  - Tutorial
+---
 # SolvingMicroDSOPs Is an Exploration of Indirect Inference for a Life Cycle Model
 
 The `do_all.py` file in SolvingMicroDSOPs is meant as a template for one kind of REMARK directory. It is a full-fledged module that can be imported and will create tools that can be used to specify the many options that govern exactly what is done by the tools in SolvingMicroDSOPs.

--- a/REMARKs/cAndCwithStickyE.md
+++ b/REMARKs/cAndCwithStickyE.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Replication
 location_url: https://github.com/llorracc/cAndCwithStickyE
 name: cAndCwithStickyE
 summary: 'Sticky Expectations and Consumption Dynamics'

--- a/REMARKs/cAndCwithStickyE.md
+++ b/REMARKs/cAndCwithStickyE.md
@@ -1,22 +1,57 @@
 ---
 tags:
   - REMARK
-  - Replication
-location_url: https://github.com/llorracc/cAndCwithStickyE
-name: cAndCwithStickyE
-summary: 'Sticky Expectations and Consumption Dynamics'
-abstract: ''
-notebook:
-authors:
-  - Christopher Carroll
-  - Edmund Crawley
-  - Jiri Slacalek
-  - Kiichi Tokuoka
-  - Matthew White
-DOI: 
+  - Reproduction
+abstract: "Sticky Expectations and Consumption Dynamics." # abstract: optional
+authors: # required
+  -  
+    family-names: Carroll
+    given-names: "Christopher D."
+    orcid: "https://orcid.org/0000-0003-3732-9312"
+  -
+    family-names: Crawley
+    given-names: "Edmund"
+    orcid: "https://orcid.org/"
+  -
+    family-names: Slacalek
+    given-names: "Jiri"
+    orcid: "https://orcid.org/"
+  -
+    family-names: Kiichi
+    given-names: "Tokuoka"
+    orcid: "https://orcid.org/"
+  -
+    family-names: White
+    given-names: "Matthew"
+    orcid: "https://orcid.org/"
+cff-version: "" # required 
+date-released:  # required
+identifiers: # optional
+  - 
+    type: url
+    value: "https://github.com/llorracc/cAndCwithStickyE"
+  - 
+    type: doi
+    value: "TODO"
+keywords: # optional
+message: "" # required
+version: "" # required
+# REMARK fields
+github_repo_url: https://github.com/llorracc/cAndCwithStickyE # required 
+commit: # Git commit number that the REMARK will always use; required for "frozen" remarks, optional for "draft" remarks
+remark-name: cAndCwithStickyE # required 
+title-original-paper: # optional 
+notebooks: # path to any notebooks within the repo - optional
+dashboards: # path to any dahsboards within the repo - optional
+identifiers-paper: # required for Replications; optional for Reproductions
+   - 
+      type: url 
+      value: 
+   - 
+      type: doi
+      value: 
+date-published-original-paper: # required for Replications; optional for Reproductions
 ---
-
-
 # cAndCwithStickyE is a Reproduction 
 
 This is a reproduction of the results in the paper "Sticky Expectations and Consumption Dynamics" by Carroll, Crawley, Slacalek, Tokuoka, and White. The [html version](http://econ.jhu.edu/people/ccarroll/papers/cAndCwithStickyE) contains links to resources including the PDF version, the presentation slides, a repo containing the paper and code, and related material

--- a/REMARKs/cstwMPC-RHetero.md
+++ b/REMARKs/cstwMPC-RHetero.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Replication
 name: cstwMPC-RHetero
 title: Can Persistent Unobserved Heterogeneity in Returns-to-Wealth Explain Wealth Inequality?
 remark_title: cstwMPC-RHetero

--- a/REMARKs/cstwMPC.md
+++ b/REMARKs/cstwMPC.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Replication
 location_url: https://github.com/llorracc/cstwMPC
 name: cstwMPC
 summary: ''

--- a/REMARKs/ctDiscrete.md
+++ b/REMARKs/ctDiscrete.md
@@ -1,4 +1,7 @@
 ---
+tags:
+  - REMARK
+  - Replication
 location_url: https://github.com/llorracc/ctDiscrete
 name: ctDiscrete
 summary: 'Analytically tractable model of the effects of nonfinancial risk on intertemporal choice'


### PR DESCRIPTION
This PR has 2 aims:
1) Add front-matter to metadata file of REMARKs so they render correctly on the updated website
2) Standardise all the metadata files to use the same format (as defined by @llorracc, see LiqConstr.md)