### PR TITLE
Add RiskyContrib Remark

### DIFF
--- a/REMARKs/RiskyContrib.md
+++ b/REMARKs/RiskyContrib.md
@@ -1,0 +1,55 @@
+---
+tags:
+  - REMARK
+
+abstract: "This paper develops a two-asset consumption-savings model and serves as
+the documentation of an open-source implementation of methods to solve and
+simulate it in the HARK toolkit. The model represents an agent who can
+save using two different assets---one risky and the other risk-free---to insure
+against fluctuations in his income, but faces frictions to transferring funds between
+assets. The flexibility of its implementation and its inclusion in the HARK
+toolkit will allow users to adapt the model to realistic life-cycle calibrations, and
+also to embedded it in heterogeneous-agents macroeconomic models."
+
+authors: # required
+  -
+    family-names: "Velásquez-Giraldo"
+    given-names: "Mateo"
+    orcid: https://orcid.org/0000-0001-7243-6776
+
+cff-version: "1.1.0" # required
+date-released: 2021-06-17 # required
+identifiers: # optional
+  -
+    type: url
+    value: "https://github.com/Mv77/RiskyContrib"
+  -
+    type: doi
+    value: 10.5281/zenodo.4977915
+
+keywords: # optional
+  - Lifecycle
+  - Portfolio Choice
+  - Social Security
+  - Open Source
+
+message: "This paper develops a two-asset consumption-savings model and serves as
+the documentation of an open-source implementation of methods to solve and
+simulate it in the HARK toolkit. The model represents an agent who can
+save using two different assets---one risky and the other risk-free---to insure
+against fluctuations in his income, but faces frictions to transferring funds between
+assets. The flexibility of its implementation and its inclusion in the HARK
+toolkit will allow users to adapt the model to realistic life-cycle calibrations, and
+also to embedded it in heterogeneous-agents macroeconomic models." # required
+
+repository-code: "https://github.com/Mv77/RiskyContrib" # optional
+title: "A Two-Asset Savings Model with an Income-Contribution Scheme" # required
+version: "v1.0.1" # required
+# REMARK fields
+github_repo_url: https://github.com/Mv77/RiskyContrib # required
+commit: # Blank because this is not a "frozen" remark - yet
+remark-name: RiskyContrib # required
+notebooks: # path to any notebooks within the repo - optional
+  -
+    Code/Python/RiskyContrib.ipynb
+---


### PR DESCRIPTION
This PR adds the remark associated with the new portfolio model in https://github.com/econ-ark/HARK/pull/832.

The REMARK's repo is https://github.com/Mv77/RiskyContrib