### PR TITLE
Documentation fix a monninger

### DIFF
--- a/REMARKs/Aiyagari.md
+++ b/REMARKs/Aiyagari.md
@@ -5,7 +5,11 @@ authors: # required
   -
     family-names: "Huang"
     given-names: "Zixuan" 
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
+    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX" 
+  -
+    family-names: "Sun"
+    given-names: "Mingzuo" 
+    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX" 
 title: AiyagariIdiosyncratic # required
 abstract: Aiyagari (1994) Replication # optional
 
@@ -15,24 +19,20 @@ reference: # required for replications; optional for reproductions; BibTex data 
   - type: article
     authors: # required
       -
-        family-names: "Krusell"
-        given-names: "Per"
+        family-names: "Aiyagari"
+        given-names: "S. Rao"
         # orcid: https://orcid.org/XXXX-XXXX-XXXX-XXXX
-      -
-        family-names: "Smith, Jr."
-        given-names: "Anthony A."
-        # orcid: https://orcid.org/XXXX-XXXX-XXXX-XXXX
-    title: "Income and Wealth Heterogeneity in the Macroeconomy"
-    doi: https://doi.org/10.1086/250034
-    date: 1998
-    publisher: Journal of political Economy
+    title: "Uninsured Idiosyncratic Risk and Aggregate Saving"
+    doi: https://doi.org/10.2307/2118417
+    date: 1994
+    publisher: The Quarterly Journal of Economics
 
 # Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/KrusellSmith # required 	
-remark-name: KrusellSmith # required 
+github_repo_url: https://github.com/econ-ark/REMARK/tree/master/REMARKs/AiyagariIdiosyncratic # required 	
+remark-name: AiyagariIdiosyncratic # required 
 notebooks: # path to any notebooks within the repo - optional
   - 
-    Code/Python/KrusellSmith.ipynb
+    Aiyagari1994QJE.ipynb
 
 tags: # Use the relavent tag
   - REMARK
@@ -41,13 +41,11 @@ tags: # Use the relavent tag
 
 
 
-# KrusellSmith
+# AiyagariIdiosyncratic
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/econ-ark/KrusellSmith/HEAD)
-
-This is a Replication of Krusell and Smith, 1998.
+This is a Replication of S. Rao Aiyagari (1994).
 
 
 ## References
 
-Krusell, P., & Smith, Jr, A. A. (1998). Income and wealth heterogeneity in the macroeconomy. Journal of political Economy, 106(5), 867-896.
+Aiyagari, S. R. (1994). Uninsured idiosyncratic risk and aggregate saving. The Quarterly Journal of Economics, 109(3), 659-684.

--- a/REMARKs/BlanchardPA2019.md
+++ b/REMARKs/BlanchardPA2019.md
@@ -7,6 +7,7 @@ authors: # required
     given-names: "Julien"
     orcid: https://orcid.org/0000-0002-6137-0537
 title: BlanchardPA2019 # required
+abstract: This notebook fully replicates the analysis of the stochastic overlapping generations (OLG) model developed by Blanchard in his presidential address during the AEA meetings 2019. # optional
 
 # REMARK fields
 remark-version: 1.1 # required - specify version of REMARK standard used

--- a/REMARKs/BufferStock-LifeCycle.md
+++ b/REMARKs/BufferStock-LifeCycle.md
@@ -15,6 +15,7 @@ authors: # required
     given-names: "Jeongwon (John)"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
 title: BufferStock-LifeCycle # required
+abstract: This is a replication of Carroll (1997), Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis. # optional
 
 # REMARK required fields
 remark-version: 1.0 # required - specify version of REMARK standard used

--- a/REMARKs/EndogenousRetirement.md
+++ b/REMARKs/EndogenousRetirement.md
@@ -6,6 +6,7 @@ authors: # required
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
 title: EndogenousRetirement # required
+abtract: Endogenous Retirement: A Canonical Discrete-Continuous Problem. This REMARK demonstrates a solution to the difficult problem of solving for the optimal retirement date given that consumption and asset choices are continuous.
 
 # REMARK required fields
 remark-version: "1.0" # required - specify version of REMARK standard used
@@ -34,3 +35,4 @@ tags: # Use the relavent tags
 
 # Endogenous Retirement: A Canonical Discrete-Continuous Problem
 
+This REMARK demonstrates a solution to the difficult problem of solving for the optimal retirement date given that consumption and asset choices are continuous.

--- a/REMARKs/EndogenousRetirement.md
+++ b/REMARKs/EndogenousRetirement.md
@@ -6,7 +6,7 @@ authors: # required
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
 title: EndogenousRetirement # required
-abtract: Endogenous Retirement: A Canonical Discrete-Continuous Problem. This REMARK demonstrates a solution to the difficult problem of solving for the optimal retirement date given that consumption and asset choices are continuous.
+abtract: Endogenous Retirement - A Canonical Discrete-Continuous Problem. This REMARK demonstrates a solution to the difficult problem of solving for the optimal retirement date given that consumption and asset choices are continuous.
 
 # REMARK required fields
 remark-version: "1.0" # required - specify version of REMARK standard used

--- a/REMARKs/GanongNoelUI.md
+++ b/REMARKs/GanongNoelUI.md
@@ -10,7 +10,7 @@ authors: # required
     given-names: "Pascal"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
 title: GanongNoelUI # required
-abstract: Analysis of Models for "Consumer Spending During Unemployment: Positive and Normative Implications"
+abstract: Analysis of Models for "Consumer Spending During Unemployment- Positive and Normative Implications"
 
 # REMARK required fields
 remark-version: "1.0" # required - specify version of REMARK standard used

--- a/REMARKs/GanongNoelUI.md
+++ b/REMARKs/GanongNoelUI.md
@@ -10,6 +10,7 @@ authors: # required
     given-names: "Pascal"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
 title: GanongNoelUI # required
+abstract: Analysis of Models for "Consumer Spending During Unemployment: Positive and Normative Implications"
 
 # REMARK required fields
 remark-version: "1.0" # required - specify version of REMARK standard used

--- a/REMARKs/PortfolioChoiceBlogPost.md
+++ b/REMARKs/PortfolioChoiceBlogPost.md
@@ -6,7 +6,7 @@ authors: # required
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
 title: Optimal Financial Investment over the Life Cycle - Blog Post
-abstract: A [blog post](https://econ-ark.github.io/PortfolioChoiceBlogPost/PortfolioChoiceBlogPost.html) showcasing use of HARK to the portfolio choice allocation problem.
+abstract: A blog post (https://econ-ark.github.io/PortfolioChoiceBlogPost/PortfolioChoiceBlogPost.html) showcasing use of HARK to the portfolio choice allocation problem.
 
 # REMARK required fields
 remark-version: "1.0" # required - specify version of REMARK standard used

--- a/REMARKs/PortfolioChoiceBlogPost.md
+++ b/REMARKs/PortfolioChoiceBlogPost.md
@@ -6,6 +6,7 @@ authors: # required
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
 title: Optimal Financial Investment over the Life Cycle - Blog Post
+abstract: A [blog post](https://econ-ark.github.io/PortfolioChoiceBlogPost/PortfolioChoiceBlogPost.html) showcasing use of HARK to the portfolio choice allocation problem.
 
 # REMARK required fields
 remark-version: "1.0" # required - specify version of REMARK standard used

--- a/REMARKs/cstwMPC.md
+++ b/REMARKs/cstwMPC.md
@@ -20,6 +20,7 @@ authors: # required
     given-names: "Matthew"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
 title: DistributionOfWealthMPC
+abstract: Replication codes for: Carroll, C., Slacalek, J., Tokuoka, K., & White, M. N. (2017). The distribution of wealth and the marginal propensity to consume. Quantitative Economics, 8(3), 977-1020.
 
 # REMARK required fields
 remark-version: 2.0

--- a/REMARKs/cstwMPC.md
+++ b/REMARKs/cstwMPC.md
@@ -20,7 +20,7 @@ authors: # required
     given-names: "Matthew"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
 title: DistributionOfWealthMPC
-abstract: Replication codes for: Carroll, C., Slacalek, J., Tokuoka, K., & White, M. N. (2017). The distribution of wealth and the marginal propensity to consume. Quantitative Economics, 8(3), 977-1020.
+abstract: Replication codes for Carroll, C., Slacalek, J., Tokuoka, K., & White, M. N. (2017). The distribution of wealth and the marginal propensity to consume. Quantitative Economics, 8(3), 977-1020.
 
 # REMARK required fields
 remark-version: 2.0


### PR DESCRIPTION
Adding abstracts to all REMARKs as they are visible in econ-ark.org

To do:
- adding meta data for: https://econ-ark.org/materials/cstwmpc-rhetero Github: https://github.com/econ-ark/cstwMPC-RHetero by Derin Aksit
@llorracc do you know if the replicated paper is published and where to find it?