### PR TITLE
Fix remark titles

### DIFF
--- a/REMARKs/Aiyagari.md
+++ b/REMARKs/Aiyagari.md
@@ -10,7 +10,7 @@ authors: # required
     family-names: "Sun"
     given-names: "Mingzuo" 
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX" 
-title: AiyagariIdiosyncratic # required
+title: "Uninsured Idiosyncratic Risk and Aggregate Saving" # required
 abstract: Aiyagari (1994) Replication # optional
 
 # REMARK required fields

--- a/REMARKs/Aiyagari.md
+++ b/REMARKs/Aiyagari.md
@@ -29,7 +29,7 @@ references: # required for replications; optional for reproductions; BibTex data
 
 # Econ-ARK website fields
 github_repo_url: https://github.com/econ-ark/Aiyagari-Idiosyncratic # required 	
-remark-name: AiyagariIdiosyncratic # required 
+remark-name: Aiyagari-Idiosyncratic # required 
 notebooks: # path to any notebooks within the repo - optional
   - 
     Aiyagari1994QJE.ipynb

--- a/REMARKs/BlanchardPA2019.md
+++ b/REMARKs/BlanchardPA2019.md
@@ -6,7 +6,7 @@ authors: # required
     family-names: "Acalin"
     given-names: "Julien"
     orcid: https://orcid.org/0000-0002-6137-0537
-title: BlanchardPA2019 # required
+title: "Public Debt and Low Interest Rates" # required
 abstract: This notebook fully replicates the analysis of the stochastic overlapping generations (OLG) model developed by Blanchard in his presidential address during the AEA meetings 2019. # optional
 
 # REMARK fields

--- a/REMARKs/BufferStock-LifeCycle.md
+++ b/REMARKs/BufferStock-LifeCycle.md
@@ -14,7 +14,7 @@ authors: # required
     family-names: "Son"
     given-names: "Jeongwon (John)"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: BufferStock-LifeCycle # required
+title: "Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis" # required
 abstract: This is a replication of Carroll (1997), Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis. # optional
 
 # REMARK required fields

--- a/REMARKs/DistributionOfWealthMPC.md
+++ b/REMARKs/DistributionOfWealthMPC.md
@@ -19,7 +19,7 @@ authors: # required
     family-names: "White"
     given-names: "Matthew"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: DistributionOfWealthMPC
+title: "The distribution of wealth and the marginal propensity to consume"
 
 # REMARK required fields
 remark-version: 2.0

--- a/REMARKs/DurableConsumerType.md
+++ b/REMARKs/DurableConsumerType.md
@@ -13,7 +13,7 @@ date-released: 2022-09-01 # required
 
 # REMARK required fields
 remark-version: 1.0 # required - specify version of REMARK standard used
-reference: # required for replications; optional for reproductions; BibTex data from original paper
+references: # required for replications; optional for reproductions; BibTex data from original paper
   - type: article
     authors: # required
       -

--- a/REMARKs/DurableConsumerType.md
+++ b/REMARKs/DurableConsumerType.md
@@ -6,7 +6,7 @@ authors: # required
     family-names: "Monninger"
     given-names: "Adrian B." 
     orcid: "https://orcid.org/0000-0001-5978-5621"
-title: DurableConsumerType # required
+title: "A Guide on Solving Non-convex Consumption-Saving Models" # required
 abstract: This REMARK replicates Druedahl, J. (2021). A guide on solving non-convex consumption-saving models.
  # optional
 date-released: 2022-09-01 # required

--- a/REMARKs/EndogenousRetirement.md
+++ b/REMARKs/EndogenousRetirement.md
@@ -5,7 +5,7 @@ authors: # required
   - family-names: "Carroll"
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
-title: EndogenousRetirement # required
+title: "Endogenous Retirement: A Canonical Discrete-Continuous Problem" # required
 abstract: Endogenous Retirement - A Canonical Discrete-Continuous Problem. This REMARK demonstrates a solution to the difficult problem of solving for the optimal retirement date given that consumption and asset choices are continuous.
 
 # REMARK required fields

--- a/REMARKs/GanongNoelUI.md
+++ b/REMARKs/GanongNoelUI.md
@@ -9,7 +9,7 @@ authors: # required
   - family-names: "Noel"
     given-names: "Pascal"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: GanongNoelUI # required
+title: "Consumer Spending during Unemployment: Positive and Normative Implications" # required
 abstract: Analysis of Models for "Consumer Spending During Unemployment- Positive and Normative Implications"
 
 # REMARK required fields

--- a/REMARKs/GanongNoelUI.md
+++ b/REMARKs/GanongNoelUI.md
@@ -31,7 +31,7 @@ references: # required for replications; optional for reproductions; BibTex data
     publisher: "The American Economic Review"
 
 # Econ-ARK website fields 
-github_repo_url: "https://github.com/econ-ark/REMARK" # required 
+github_repo_url: "https://github.com/econ-ark/GanongNoelUI" # required 
 remark-name: "GanongNoelUI" # required
 title-original-paper: "Consumer Spending During Unemployment: Positive and Normative Implications" # optional 
 

--- a/REMARKs/KrusellSmith.md
+++ b/REMARKs/KrusellSmith.md
@@ -5,7 +5,7 @@ authors: # required
   - family-names: "Carroll"
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
-title: "KrusellSmith" # required
+title: "Income and Wealth Heterogeneity in the Macroeconomy" # required
 abstract: "Income and wealth heterogeneity in the macroeconomy" # optional
 
 # REMARK required fields

--- a/REMARKs/cAndCwithStickyE.md
+++ b/REMARKs/cAndCwithStickyE.md
@@ -22,7 +22,7 @@ authors: # required
     family-names: "White"
     given-names: "Matthew"
     # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title:  cAndCwithStickyE # required
+title: "Sticky Expectations and Consumption Dynamics" # required
 abstract: "Sticky Expectations and Consumption Dynamics." # abstract: optional
 
 # REMARK required fields

--- a/REMARKs/ctDiscrete.md
+++ b/REMARKs/ctDiscrete.md
@@ -6,7 +6,7 @@ authors: # required
   - family-names: "Carroll"
     given-names: "Christopher D."
     orcid: "https://orcid.org/0000-0003-3732-9312"
-title: ctDiscrete # required
+title: "A Tractable Model of Buffer Stock Saving" # required
 abstract: 'Analytically tractable model of the effects of nonfinancial risk on intertemporal choice'  # optional
 
 # REMARK required fields


### PR DESCRIPTION
This PR fixes various titles on the REMARKs. This will cause the downstream website to display these more descriptive titles instead of the previous shorthand titles for a better user experience.

@ccarrollATjhuecon @llorracc if you have a moment can you do a quick review to ensure these titles appear correct for the REMARK that they refer to?