### PR TITLE
Enable v1.0.0 tag for MethodOfModeration

### DIFF
--- a/REMARKs/MethodOfModeration.yml
+++ b/REMARKs/MethodOfModeration.yml
@@ -1,4 +1,4 @@
 name: MethodOfModeration
 remote: https://github.com/econ-ark/method-of-moderation
 title: The Method of Moderation
-# tag: v1.0.0  ## Uncomment after creating tagged release
+tag: v1.0.0


### PR DESCRIPTION
## Summary
- Enables the v1.0.0 release tag for the Method of Moderation REMARK
- Tag was created and pushed to https://github.com/econ-ark/method-of-moderation

## Release Highlights
The Method of Moderation REMARK v1.0.0 includes:
- Complete MoM, MoM-CRRA, and MoM-HARA solver implementations
- Three-piece cusp approximation for tighter consumption bounds
- Comprehensive test suite validating theoretical properties
- Economics Letters paper format (within 2,000 word limit)
- Full MyST documentation with PDF exports
- Binder-ready for reproducibility

## Test plan
- [x] Tag v1.0.0 exists: https://github.com/econ-ark/method-of-moderation/releases/tag/v1.0.0
- [ ] REMARK catalog builds successfully with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)