### PR TITLE
Update HAFiscal catalog entry: add v1.0.3 tag

### DIFF
--- a/REMARKs/HAFiscal.yml
+++ b/REMARKs/HAFiscal.yml
@@ -1,3 +1,4 @@
 name: HAFiscal
 remote: https://github.com/econ-ark/HAFiscal
 title: Welfare and Spending Effects of Consumption Stimulus Policies
+tag: v1.0.3

--- a/REMARKs/HAFiscal.yml
+++ b/REMARKs/HAFiscal.yml
@@ -1,4 +1,4 @@
 name: HAFiscal
 remote: https://github.com/econ-ark/HAFiscal
 title: Welfare and Spending Effects of Consumption Stimulus Policies
-tag: v1.0.3
+tag: v1.0.7


### PR DESCRIPTION
## Summary

Updates the HAFiscal REMARK catalog entry to include the v1.0.3 tag, which corresponds to the Published REMARK version archived on Zenodo (DOI: 10.5281/zenodo.17861977).

## Changes

- Add `tag: v1.0.3` to REMARKs/HAFiscal.yml

## Context

HAFiscal was previously added to the REMARK catalog (PR #167, merged Dec 9, 2025). This update ensures the catalog entry points to the specific version (v1.0.3) that was archived on Zenodo for Published REMARK status.

## Verification

- Zenodo DOI: 10.5281/zenodo.17861977
- Tag v1.0.3 exists in both llorracc/HAFiscal-Public and econ-ark/HAFiscal
- Published REMARK requirements met (8/8)