### PR TITLE
Add Life-Cycle-Prime-Time to REMARK catalog

### DIFF
--- a/REMARKs/LifeCyclePrimeTime.yml
+++ b/REMARKs/LifeCyclePrimeTime.yml
@@ -1,0 +1,4 @@
+name: LifeCyclePrimeTime
+remote: https://github.com/econ-ark/Life-Cycle-Prime-Time
+title: Life-Cycle-Prime-Time
+tag: v0.1.0


### PR DESCRIPTION
Adds Life-Cycle-Prime-Time to the REMARK catalog as a Tier 2 (Reproducible REMARK).

**Catalog entry:** `REMARKs/LifeCyclePrimeTime.yml`
- **Repository:** https://github.com/econ-ark/Life-Cycle-Prime-Time
- **Tag:** v0.1.0
- **Title:** Life-Cycle-Prime-Time

The repository meets REMARK Tier 2 requirements (Dockerfile, reproduce.sh, reproduce_min.sh, binder/environment.yml, README ≥100 lines, CITATION.cff, REMARK.md, tagged release).

Made with [Cursor](https://cursor.com)