### PR TITLE
Add REMARK: Low2005 (Econ 606 course project by Jiaxuan Zhang)

### DIFF
--- a/REMARKs/Low2005.yml
+++ b/REMARKs/Low2005.yml
@@ -1,0 +1,4 @@
+name: Low2005
+remote: https://github.com/jzhan476/Low2005
+title: Self-Insurance in a Life-Cycle Model of Labour Supply and Savings
+tag: v1.1.0

--- a/REMARKs/Low2005.yml
+++ b/REMARKs/Low2005.yml
@@ -1,4 +1,4 @@
 name: Low2005
 remote: https://github.com/jzhan476/Low2005
-title: Self-Insurance in a Life-Cycle Model of Labour Supply and Savings
+title: Self-Insurance in a Life-Cycle Model of Labor Supply and Savings
 tag: v1.1.0

--- a/REMARKs/Low2005.yml
+++ b/REMARKs/Low2005.yml
@@ -1,4 +1,4 @@
 name: Low2005
 remote: https://github.com/jzhan476/Low2005
-title: Self-Insurance in a Life-Cycle Model of Labor Supply and Savings
+title: Self-Insurance in a Life-Cycle Model of Labour Supply and Savings
 tag: v1.1.0


### PR DESCRIPTION
## Summary

Updates the catalog entry **`REMARKs/Low2005.yml`** for **[Low2005](https://github.com/jzhan476/Low2005)**, a **Tier-2 REMARK** reproducing **Low (2005)**, *Self-Insurance in a Life-Cycle Model of Labour Supply and Savings*, *Review of Economic Dynamics*, 8(4), 945–975 ([DOI](https://doi.org/10.1016/j.red.2005.03.002)).

[![Reproducibility](https://github.com/jzhan476/Low2005/actions/workflows/reproduce.yml/badge.svg)](https://github.com/jzhan476/Low2005/actions/workflows/reproduce.yml)
[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://github.com/jzhan476/Low2005/blob/main/LICENSE)
[![Python](https://img.shields.io/badge/Python-3.11-blue.svg)](https://github.com/jzhan476/Low2005/blob/main/pyproject.toml)
[![REMARK Tier 2](https://img.shields.io/badge/REMARK-Tier%202-success.svg)](https://github.com/econ-ark/REMARK)

## Repository

- **URL:** https://github.com/jzhan476/Low2005
- **Release:** [v1.1.0](https://github.com/jzhan476/Low2005/releases/tag/v1.1.0)
- **CI:** `./reproduce.sh --comp min` runs on every push and PR via [`.github/workflows/reproduce.yml`](https://github.com/jzhan476/Low2005/blob/main/.github/workflows/reproduce.yml); all five figures are regenerated and uploaded as a build artifact.

## What is reproduced

Main quantitative comparisons in Low (2005): life-cycle profiles; certainty vs. uncertainty; flexible vs. fixed labour supply under uncertainty.

| Component | Implementation |
|-----------|----------------|
| Flexible hours + wage risk | `HARK.ConsumptionSaving.ConsLaborModel.LaborIntMargConsumerType` |
| Fixed hours + wage risk   | `HARK.ConsumptionSaving.ConsIndShockModel.IndShockConsumerType`  |
| Output                    | Five figures in `Figures/` (captions reference Low 2005 Figs. 3–7) |

Working life is solved in HARK; **retirement (ages 65–84)** is appended as a **deterministic continuation** for plotting (documented in the paper PDF and code — `LaborIntMargConsumerType` requires strictly positive wages each period).

## Replication targets

Lifted from `Low2005.pdf` (Table 2, baseline calibration):

| Statistic (working life)            | Low (2005) | This replication  |
|-------------------------------------|:----------:|:----------------:|
| Mean hours, fraction of time worked | 0.40       | 0.36            |
| Peak-assets age (full life cycle)   | $\sim 60$  | 56               |

Qualitative results from Low (2005), Figs. 3–7 (uncertainty raises early-life hours, raises peak assets, flexible hours dampen precautionary saving, hump-shaped consumption) all reproduce.

## Reproduction

```bash
git clone https://github.com/jzhan476/Low2005.git
cd Low2005
git checkout v1.1.0
uv sync --frozen --no-dev
./reproduce.sh --comp min        # ~2–3 min: regenerates the five figures
./reproduce.sh --docs main       # rebuilds Low2005.pdf
# Full pipeline: ./reproduce.sh --all
```

Binder: `binder/environment.yml` (Python 3.11) + `binder/postBuild` → `uv sync --frozen`. Local installs: `requires-python = ">=3.9,<3.13"` in `pyproject.toml`.

## Tier-2 REMARK compliance

- [x] Tagged release **v1.1.0** on `main` + GitHub Release
- [x] `reproduce.sh`, `reproduce_min.sh`
- [x] Root `Dockerfile`
- [x] `LICENSE` (Apache-2.0)
- [x] `binder/environment.yml`, `binder/postBuild`, pinned `uv.lock`
- [x] `README.md` (≥100 non-empty lines)
- [x] `REMARK.md` with `tier: 2`, CFF-style frontmatter, and notebook pointer (`Code/Python/Low2005.ipynb`)
- [x] `CITATION.cff` at v1.1.0
- [x] **GitHub Actions CI** verifying `reproduce.sh --comp min` on every push/PR

## Updates since the previous catalog version

The artifact has been substantively upgraded in the v1.1.0 commit history:

- **CI workflow** (`.github/workflows/reproduce.yml`) — installs the locked Python environment, runs `reproduce.sh --comp min`, verifies the five expected PNGs are non-empty, and uploads them as an artifact.
- **`REMARK.md` expanded** from a sparse stub to ~180 lines including a full description of what is reproduced, replication targets, computational requirements, expected outputs, and a Tier-2 compliance checklist.
- **Bibliography expanded** in `Low2005.bib` (6 → 19 entries, all cited in `Low2005.tex`); a brief related-literature pointer added to the Summary section.
- **Replication targets table** in `Low2005.pdf` now reports residuals in absolute units (rather than percentages alone).
- **`@local/metadata.ltx`** corrected (authors / funding / keywords / JEL codes now match this REMARK rather than the template).

## Catalog file

`REMARKs/Low2005.yml`:

```yaml
name: Low2005
remote: https://github.com/jzhan476/Low2005
title: Self-Insurance in a Life-Cycle Model of Labour Supply and Savings
tag: v1.1.0
```

## Relation to prior PR

Updates **[PR #181](https://github.com/econ-ark/REMARK/pull/181)** for the same **Low2005** remote; the catalog **`tag`** should be **`v1.1.0`**.
