### PR TITLE
Add calbafa606: Mexico monetary policy shocks REMARK

### DIFF
--- a/REMARKs/calbafa606.yml
+++ b/REMARKs/calbafa606.yml
@@ -1,0 +1,19 @@
+name: calbafa606
+title: "Monetary Policy Surprises and Macroeconomic Outcomes in Mexico"
+author: "Carlos Alba"
+
+description: >
+  This project studies the effects of high-frequency monetary policy surprises,
+  decomposed into target rate and forward guidance shocks, on macroeconomic and financial variables.
+
+repo_url: https://github.com/Calbafa/calbafa606
+
+category: monetary
+
+tags:
+  - monetary policy
+  - high-frequency identification
+  - forward guidance
+  - empirical macro
+
+status: in-progress


### PR DESCRIPTION
## Summary

Adds a catalog entry for **calbafa606** — a REMARK studying the effects of monetary policy shocks in Mexico using high-frequency identification.

- **Paper**: "Disentangling Monetary Policy, Central Bank Information, and Response-to-News Shocks: Evidence from Mexico"
- **Author**: Carlos Alba (Johns Hopkins University)
- **Repo**: https://github.com/Calbafa/calbafa606
- **Methodology**: Adapts Jarociński and Karadi (2020) high-frequency identification to Banco de México announcements, decomposing surprises into monetary policy (MP), central bank information (CBI), and response-to-news (RN) shocks. Macroeconomic effects are estimated via a sign-restricted Bayesian VAR.

The repository includes `reproduce.sh`, `Dockerfile`, `binder/environment.yml`, `CITATION.cff`, `REMARK.md`, and a tagged release (v1.0.0), targeting Tier 2 (Reproducible REMARK) compliance.

## Checklist
- [x] `REMARKs/calbafa606.yml` added with `remote` and `title` fields
- [x] Source repo has `reproduce.sh`, `Dockerfile`, `binder/environment.yml`
- [x] Source repo has `CITATION.cff`, `LICENSE`, `REMARK.md`
- [x] Tagged release v1.0.0 exists


Made with [Cursor](https://cursor.com)